### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ HOOKS=(setvtrgb consolefont base udev modconf block keyboard zfs filesystems)
 [...]
 :wq
 
-mkinitcpio -plinux
+mkinitcpio -p linux
 ```
 
 Issues or Contributions


### PR DESCRIPTION
There was a missing space in the command, changed from
`mkinitcpio -plinux`
to
`mkinitcpio -p linux`