### PR TITLE
Added sd-setvtrgb hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ HOOKS=(setvtrgb consolefont base udev modconf block keyboard zfs filesystems)
 mkinitcpio -p linux
 ```
 
+If using `systemd` and `sd-vconsole`, use the `sd-setvtrgb` service hook instead:
+```
+vim /etc/mkinitcpio.conf
+/HOOKS
+
+[...]
+HOOKS=(base systemd sd-setvtrgb sd-vconsole modconf block keyboard zfs filesystems)
+[...]
+:wq
+
+mkinitcpio -p linux
+```
+
 Issues or Contributions
 -----------------------
 

--- a/initcpio/install/sd-setvtrgb
+++ b/initcpio/install/sd-setvtrgb
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+
+build() {
+    # configuration file is required or we will do nothing
+    test -r /etc/vtrgb || return
+ 
+    add_file `readlink -e /etc/vtrgb` /etc/vtrgb
+    add_binary setvtrgb
+    add_systemd_unit "setvtrgb.service"
+    add_symlink "/usr/lib/systemd/system/initrd.target.wants/setvtrgb.service" "setvtrgb.service"
+}
+
+
+help() {
+    cat <<HELPEOF
+    This hook calls the setvtrgb program to apply the currently configured
+    color scheme during the early boot process. It uses /etc/vtrgb as its
+    configuration file.
+HELPEOF
+}
+
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/setvtrgb.service
+++ b/setvtrgb.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Setup the console vtrgb colors
+DefaultDependencies=no
+ConditionPathExists=/etc/vtrgb
+
+[Service]
+Type=oneshot
+ExecStart=setvtrgb /etc/vtrgb


### PR DESCRIPTION
Hi, first of all thanks for this project!

I hope you don't mind I've added a systemd `sd-setvtrgb` hook and associated service, to make it work when using `sd-vconsole` instead of `consolefont`