### PR TITLE
Fixes `sd-setvtrgb`'s `add_symlink`

### DIFF
--- a/initcpio/install/sd-setvtrgb
+++ b/initcpio/install/sd-setvtrgb
@@ -8,7 +8,7 @@ build() {
     add_file `readlink -e /etc/vtrgb` /etc/vtrgb
     add_binary setvtrgb
     add_systemd_unit "setvtrgb.service"
-    add_symlink "/usr/lib/systemd/system/initrd.target.wants/setvtrgb.service" "setvtrgb.service"
+    add_symlink "/usr/lib/systemd/system/initrd.target.wants/setvtrgb.service" "../setvtrgb.service"
 }
 
 


### PR DESCRIPTION
Currently, it fails with:
```log
Failed to chase '/usr/lib/systemd/system/initrd.target.wants/setvtrgb.service': Too many levels of symbolic links
```

My guess is that the symlink is pointing to itself; so the fix is to point to the actual file (just like with `ln`).

Fixes #4

Edit:
The [AUR package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=base16-vtrgb#n32) creates the same symlink in the main filesystem that, apart from being unused and  harmless, it creates confusion with the mkinitcpio hook that works on initramfs.